### PR TITLE
feat(rulesets): add `exempt` as a bypass option

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -64,8 +64,8 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 						"bypass_mode": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request"}, false),
-							Description:  "When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`.",
+							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request", "exempt"}, false),
+							Description:  "When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests, exempt means that rule will be silently skipped. Can be one of: `always`, `pull_request` or `exempt`.",
 						},
 					},
 				},

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -19,6 +19,12 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 				target      = "branch"
 				enforcement = "active"
 
+				bypass_actors {
+					actor_id = 0
+					actor_type = "OrganizationAdmin"
+					bypass_mode = "exempt"
+				}
+
 				conditions {
 					ref_name {
 						include = ["~ALL"]

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -69,8 +69,8 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 						"bypass_mode": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request"}, false),
-							Description:  "When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`.",
+							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request", "exempt"}, false),
+							Description:  "When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests, exempt means that rule will be silently skipped. Can be one of: `always`, `pull_request` or `exempt`.",
 						},
 					}},
 			},


### PR DESCRIPTION
This adds `exempt` as a ruleset bypass option alognside already existing `pull_request` and `always`. 

I need to check if GitHub API is ready to handle this addition.

cf. https://github.blog/changelog/2025-09-10-github-ruleset-exemptions-and-repository-insights-updates/